### PR TITLE
Tested up to: 5.3 & Requires PHP: 5.6

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: jamiebergen
 Tags: plugins, plugin notes, memo
 Donate link: https://jamiebergen.com/donate/
 Requires at least: 4.0
-Tested up to: 5.2.3
-Requires PHP: 5.5.24
+Tested up to: 5.3
+Requires PHP: 5.6
 Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress 5.3 is here. The plugin works with the new version.

Also, the minimum PHP version required to run WordPress is 5.6, the plugin should use the same minimum requirements.